### PR TITLE
fix: use current time for telegram_message_time when delete_and_resend is true

### DIFF
--- a/src/handlers/doses.rs
+++ b/src/handlers/doses.rs
@@ -125,7 +125,10 @@ pub async fn record(
     .await?;
 
     if let Some(sent_message_id) = sent_message_id {
-        let message_time = reminder_sent_time.unwrap_or_else(now);
+        let message_time = match config.trufotbot_reminder_completion_delete_and_resend {
+            true => now(),
+            false => reminder_sent_time.unwrap_or_else(now),
+        };
 
         let res = sqlx::query!(
             r#"

--- a/src/handlers/reminders.rs
+++ b/src/handlers/reminders.rs
@@ -411,4 +411,140 @@ mod tests {
     async fn remind_dose_succeeds_with_delete_and_resend(db: SqlitePool) {
         test_remind_dose(db, true).await;
     }
+
+    #[sqlx::test(fixtures("../fixtures/patients.sql", "../fixtures/medications.sql"))]
+    async fn remind_dose_then_edit_succeeds_with_delete_and_resend(db: SqlitePool) {
+        let fake_telegram = Arc::new(FakeSender::new());
+        let messenger = fake_telegram.clone().into();
+        let config = Arc::new(Config {
+            trufotbot_reminder_completion_delete_and_resend: true,
+            trufotbot_show_dose_absolute_time: true,
+            ..Config::load().unwrap()
+        });
+        let app_state = AppState::new(db, messenger, config.clone()).await.unwrap();
+
+        let taken_at = DateTime::parse_from_rfc3339("2025-01-02T00:00:00Z")
+            .unwrap()
+            .to_utc();
+        let reminded_at = DateTime::parse_from_rfc3339("2025-01-01T23:00:00Z")
+            .unwrap()
+            .to_utc();
+
+        // Send reminder at FAKE_TIME = 2025-01-02T00:00:00Z
+        FAKE_TIME
+            .scope("2025-01-02T00:00:00Z", async {
+                send_reminder(
+                    State(app_state.storage.clone()),
+                    State(app_state.messenger.clone()),
+                    State(app_state.config.clone()),
+                    Path((1, 1)),
+                )
+                .await
+                .unwrap();
+            })
+            .await;
+
+        // Record dose from reminder (with reminded_at = 1 hour before now, taken_at = now)
+        FAKE_TIME
+            .scope("2025-01-02T00:00:00Z", async {
+                crate::handlers::doses::record(
+                    Path((1, 1)),
+                    Query(CreateDoseQueryParams {
+                        reminder_message_id: Some(1),
+                        reminder_sent_time: Some(reminded_at),
+                    }),
+                    State(app_state.storage.clone()),
+                    State(app_state.messenger.clone()),
+                    State(app_state.config.clone()),
+                    Json(dose::CreateDose {
+                        quantity: 2.0,
+                        taken_at,
+                        noted_by_user: Some("Albert".to_string()),
+                    }),
+                )
+                .await
+                .unwrap();
+            })
+            .await;
+
+        // Verify initial message says "now" (message_time = taken_at = now())
+        assert_eq!(
+            fake_telegram.messages.get_messages(-123).await.unwrap(),
+            messages_from_slice(
+                &[(
+                    r"✅ Albert gave Alice Aspirin \(2\) now \(2025\-01\-02 \(Thu\) 00:00\)",
+                    &[
+                        (
+                            "Edit... ✏️",
+                            callbacks::Action::Link {
+                                url: url::Url::parse(
+                                    "http://0.0.0.0:8080/patients/1/medications/1/doses/1"
+                                )
+                                .unwrap()
+                            }
+                        ),
+                        (
+                            "Repeat 🔁",
+                            callbacks::Action::TakeNew {
+                                patient_id: 1,
+                                medication_id: 1,
+                                quantity: 2.0,
+                            },
+                        )
+                    ]
+                )],
+                2
+            )
+        );
+
+        // Update the dose (edit) at FAKE_TIME = 2025-01-02T00:05:00Z
+        FAKE_TIME
+            .scope("2025-01-02T00:05:00Z", async {
+                crate::handlers::doses::update(
+                    Path((1, 1, 1)),
+                    State(app_state.messenger.clone()),
+                    State(app_state.storage.clone()),
+                    State(app_state.config.clone()),
+                    Json(dose::CreateDose {
+                        quantity: 1.0,
+                        taken_at,
+                        noted_by_user: Some("Bob".to_string()),
+                    }),
+                )
+                .await
+                .unwrap();
+            })
+            .await;
+
+        // Verify edited message still says "now" (DB-stored telegram_message_time = now(), not
+        // reminded_at).
+        assert_eq!(
+            fake_telegram.messages.get_messages(-123).await.unwrap(),
+            messages_from_slice(
+                &[(
+                    r"✏️ Bob gave Alice Aspirin \(1\) now \(2025\-01\-02 \(Thu\) 00:00\)",
+                    &[
+                        (
+                            "Edit... ✏️",
+                            callbacks::Action::Link {
+                                url: url::Url::parse(
+                                    "http://0.0.0.0:8080/patients/1/medications/1/doses/1"
+                                )
+                                .unwrap()
+                            }
+                        ),
+                        (
+                            "Repeat 🔁",
+                            callbacks::Action::TakeNew {
+                                patient_id: 1,
+                                medication_id: 1,
+                                quantity: 1.0,
+                            },
+                        )
+                    ]
+                )],
+                2
+            )
+        );
+    }
 }


### PR DESCRIPTION
When recording a dose from a reminder with delete_and_resend=true, the telegram_message_time stored in the database was the old reminder_sent_time instead of the current time. This caused subsequent edits to display the relative time from the original reminder, e.g. "2 minutes later", even though a new message was just sent at the current time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reminder message time handling when doses are edited, ensuring accurate timestamp displays in reminder notifications.

* **Tests**
  * Added test coverage for reminder completion and dose editing workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lutzky/trufotbot/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->