### PR TITLE
Simplify test helpers: test_utils module, shared factories, dynamic URLs, rstest fixtures

### DIFF
--- a/src/handlers/doses.rs
+++ b/src/handlers/doses.rs
@@ -737,6 +737,7 @@ mod tests {
             fake_sender::{FakeSender, messages_from_slice},
             nil_sender::NilSender,
         },
+        test_utils::{dose_keyboard, dt, md},
         time::FAKE_TIME,
     };
 
@@ -752,9 +753,15 @@ mod tests {
 
     #[fixture]
     fn taken_at() -> DateTime<Utc> {
-        DateTime::parse_from_rfc3339("2025-01-01T23:00:00Z")
-            .unwrap()
-            .to_utc()
+        dt("2025-01-01T23:00:00Z")
+    }
+
+    #[fixture]
+    fn config_with_absolute_time() -> Config {
+        Config {
+            trufotbot_show_dose_absolute_time: true,
+            ..Config::load().unwrap()
+        }
     }
 
     #[rstest]
@@ -807,12 +814,8 @@ mod tests {
         #[case] medication_name: &str,
         #[case] expected: &str,
         taken_at: DateTime<Utc>,
+        config_with_absolute_time: Config,
     ) {
-        let config = Config {
-            trufotbot_show_dose_absolute_time: true,
-            ..Config::load().unwrap()
-        };
-
         let payload = CreateDose {
             quantity,
             taken_at,
@@ -830,12 +833,15 @@ mod tests {
             dose_limits: vec![],
             inventory: None,
         };
-        let message_time = DateTime::parse_from_rfc3339("2025-01-02T00:00:00Z")
-            .unwrap()
-            .to_utc();
         assert_eq!(
             expected,
-            dose_message(&config, &payload, &patient, &medication, message_time)
+            dose_message(
+                &config_with_absolute_time,
+                &payload,
+                &patient,
+                &medication,
+                dt("2025-01-02T00:00:00Z")
+            )
         );
     }
 
@@ -863,13 +869,16 @@ mod tests {
             dose_limits: vec![],
             inventory: None,
         };
-        let message_time = DateTime::parse_from_rfc3339("2025-01-02T00:00:00Z")
-            .unwrap()
-            .to_utc();
 
         assert_eq!(
             "Bob gave Alice RelativeTime-ium (1) an hour earlier",
-            dose_message(&config, &payload, &patient, &medication, message_time)
+            dose_message(
+                &config,
+                &payload,
+                &patient,
+                &medication,
+                dt("2025-01-02T00:00:00Z")
+            )
         );
     }
 
@@ -884,12 +893,8 @@ mod tests {
         #[case] seconds_after_reminder: i64,
         #[case] expected: &str,
         taken_at: DateTime<Utc>,
+        config_with_absolute_time: Config,
     ) {
-        let config = Config {
-            trufotbot_show_dose_absolute_time: true,
-            ..Config::load().unwrap()
-        };
-
         FAKE_TIME.sync_scope("2025-01-02T00:00:00Z", || {
             let payload = CreateDose {
                 quantity: 2.0,
@@ -911,20 +916,29 @@ mod tests {
             let reminder_time = taken_at - TimeDelta::seconds(seconds_after_reminder);
             assert_eq!(
                 expected,
-                dose_message(&config, &payload, &patient, &medication, reminder_time)
+                dose_message(
+                    &config_with_absolute_time,
+                    &payload,
+                    &patient,
+                    &medication,
+                    reminder_time
+                )
             );
         });
     }
 
     #[sqlx::test(fixtures("../fixtures/patients.sql"))]
     async fn record_dose_fails_with_nonexistent_medication(db: SqlitePool) {
-        let config = Config {
-            trufotbot_show_dose_absolute_time: true,
-            ..Config::load().unwrap()
-        };
-        let app_state = AppState::new(db, NilSender::new().into(), config.into())
-            .await
-            .unwrap();
+        let app_state = AppState::new(
+            db,
+            NilSender::new().into(),
+            Arc::new(Config {
+                trufotbot_show_dose_absolute_time: true,
+                ..Config::load().unwrap()
+            }),
+        )
+        .await
+        .unwrap();
 
         let result = record(
             Path((1, 999)),
@@ -952,17 +966,14 @@ mod tests {
             trufotbot_show_dose_absolute_time: true,
             ..Config::load().unwrap()
         });
+        let frontend_url = config.frontend_url.clone();
 
         let fake_telegram = Arc::new(FakeSender::new());
         let messenger = fake_telegram.clone().into();
         let app_state = AppState::new(db, messenger, config.clone()).await.unwrap();
 
-        let taken_at = DateTime::parse_from_rfc3339("2025-01-01T23:00:00Z")
-            .unwrap()
-            .to_utc();
-        let want_next_dose_time = DateTime::parse_from_rfc3339("2025-01-02T00:00:00Z")
-            .unwrap()
-            .to_utc();
+        let taken_at = dt("2025-01-01T23:00:00Z");
+        let want_next_dose_time = dt("2025-01-02T00:00:00Z");
 
         // Record the initial dose
         let initial_list_result = FAKE_TIME
@@ -1017,36 +1028,12 @@ mod tests {
             }
         );
 
-        fn want_kbd_with_quantity(
-            quantity: f64,
-        ) -> std::vec::Vec<(&'static str, crate::messenger::callbacks::Action)> {
-            vec![
-                (
-                    "Edit... ✏️",
-                    callbacks::Action::Link {
-                        url: url::Url::parse(
-                            "http://0.0.0.0:8080/patients/1/medications/1/doses/1",
-                        )
-                        .unwrap(),
-                    },
-                ),
-                (
-                    "Repeat 🔁",
-                    callbacks::Action::TakeNew {
-                        patient_id: 1,
-                        medication_id: 1,
-                        quantity,
-                    },
-                ),
-            ]
-        }
-
         assert_eq!(
             fake_telegram.messages.get_messages(-123).await.unwrap(),
             messages_from_slice(
                 &[(
-                    r"Alice took Aspirin \(2\) an hour earlier \(2025\-01\-01 \(Wed\) 23:00\)",
-                    &want_kbd_with_quantity(2.0),
+                    &md("Alice took Aspirin (2) an hour earlier (2025-01-01 (Wed) 23:00)"),
+                    &dose_keyboard(1, 1, 1, 2.0, &frontend_url),
                 )],
                 1
             )
@@ -1076,8 +1063,8 @@ mod tests {
             fake_telegram.messages.get_messages(-123).await.unwrap(),
             messages_from_slice(
                 &[(
-                    r"✏️ Bob gave Alice Aspirin \(1\) an hour earlier \(2025\-01\-01 \(Wed\) 23:00\)",
-                    &want_kbd_with_quantity(1.0),
+                    &md("✏️ Bob gave Alice Aspirin (1) an hour earlier (2025-01-01 (Wed) 23:00)"),
+                    &dose_keyboard(1, 1, 1, 1.0, &frontend_url),
                 )],
                 1
             )

--- a/src/handlers/reminders.rs
+++ b/src/handlers/reminders.rs
@@ -266,20 +266,27 @@ mod tests {
 
     use super::*;
 
+    use crate::test_utils::{dose_keyboard, dt, md, reminder_url};
     use crate::{
         app_state::AppState,
         messenger::fake_sender::{FakeSender, messages_from_slice},
     };
 
-    async fn test_remind_dose(db: SqlitePool, delete_and_resend: bool) {
+    async fn setup(db: SqlitePool, config: Arc<Config>) -> (AppState, Arc<FakeSender>) {
         let fake_telegram = Arc::new(FakeSender::new());
         let messenger = fake_telegram.clone().into();
-        let config = Config {
+        let app_state = AppState::new(db, messenger, config).await.unwrap();
+        (app_state, fake_telegram)
+    }
+
+    async fn test_remind_dose(db: SqlitePool, delete_and_resend: bool) {
+        let config = Arc::new(Config {
             trufotbot_reminder_completion_delete_and_resend: delete_and_resend,
             trufotbot_show_dose_absolute_time: true,
             ..Config::load().unwrap()
-        };
-        let app_state = AppState::new(db, messenger, config.into()).await.unwrap();
+        });
+        let frontend_url = config.frontend_url.clone();
+        let (app_state, fake_telegram) = setup(db, config).await;
 
         FAKE_TIME
             .scope("2025-01-02T00:00:00Z", async {
@@ -294,49 +301,34 @@ mod tests {
             })
             .await;
 
+        let reminder_url = reminder_url(&frontend_url, 1, 1, 1, 1735776000);
+        let keyboard = [
+            (
+                "Take 1 💊",
+                callbacks::Action::TakeFromReminder {
+                    patient_id: 1,
+                    medication_id: 1,
+                    quantity: 1.0,
+                },
+            ),
+            (
+                "Skip ⏭️",
+                callbacks::Action::TakeFromReminder {
+                    patient_id: 1,
+                    medication_id: 1,
+                    quantity: 0.0,
+                },
+            ),
+            ("Take... 📝", callbacks::Action::Link { url: reminder_url }),
+        ];
+
         assert_eq!(
             fake_telegram.messages.get_messages(-123).await.unwrap(),
-            messages_from_slice(
-                &[(
-                    r"Time for Alice to take Aspirin\.",
-                    &[
-                        (
-                            "Take 1 💊",
-                            callbacks::Action::TakeFromReminder {
-                                patient_id: 1,
-                                medication_id: 1,
-                                quantity: 1.0
-                            }
-                        ),
-                        (
-                            "Skip ⏭️",
-                            callbacks::Action::TakeFromReminder {
-                                patient_id: 1,
-                                medication_id: 1,
-                                quantity: 0.0
-                            }
-                        ),
-                        (
-                            "Take... 📝",
-                            callbacks::Action::Link {
-                                url: url::Url::parse(
-                                    "http://0.0.0.0:8080/patients/1/medications/1?message_id=1&message_time=1735776000"
-                                )
-                                .unwrap()
-                            }
-                        )
-                    ]
-                )],
-                1
-            )
+            messages_from_slice(&[(&md("Time for Alice to take Aspirin."), &keyboard)], 1)
         );
 
-        let taken_at = DateTime::parse_from_rfc3339("2025-01-01T23:00:00Z")
-            .unwrap()
-            .to_utc();
-        let reminded_at = DateTime::parse_from_rfc3339("2025-01-01T22:00:00Z")
-            .unwrap()
-            .to_utc();
+        let taken_at = dt("2025-01-01T23:00:00Z");
+        let reminded_at = dt("2025-01-01T22:00:00Z");
 
         FAKE_TIME
             .scope("2025-01-02T00:00:00Z", async {
@@ -362,12 +354,12 @@ mod tests {
 
         let (expected_text, expected_id) = if delete_and_resend {
             (
-                r"✅ Albert gave Alice Aspirin \(2\) an hour earlier \(2025\-01\-01 \(Wed\) 23:00\)",
+                md("✅ Albert gave Alice Aspirin (2) an hour earlier (2025-01-01 (Wed) 23:00)"),
                 2,
             )
         } else {
             (
-                r"✅ Albert gave Alice Aspirin \(2\) an hour later \(2025\-01\-01 \(Wed\) 23:00\)",
+                md("✅ Albert gave Alice Aspirin (2) an hour later (2025-01-01 (Wed) 23:00)"),
                 1,
             )
         };
@@ -375,28 +367,7 @@ mod tests {
         assert_eq!(
             fake_telegram.messages.get_messages(-123).await.unwrap(),
             messages_from_slice(
-                &[(
-                    expected_text,
-                    &[
-                        (
-                            "Edit... ✏️",
-                            callbacks::Action::Link {
-                                url: url::Url::parse(
-                                    "http://0.0.0.0:8080/patients/1/medications/1/doses/1"
-                                )
-                                .unwrap()
-                            }
-                        ),
-                        (
-                            "Repeat 🔁",
-                            callbacks::Action::TakeNew {
-                                patient_id: 1,
-                                medication_id: 1,
-                                quantity: 2.0,
-                            },
-                        )
-                    ]
-                )],
+                &[(&expected_text, &dose_keyboard(1, 1, 1, 2.0, &frontend_url),)],
                 expected_id
             )
         );
@@ -414,21 +385,16 @@ mod tests {
 
     #[sqlx::test(fixtures("../fixtures/patients.sql", "../fixtures/medications.sql"))]
     async fn remind_dose_then_edit_succeeds_with_delete_and_resend(db: SqlitePool) {
-        let fake_telegram = Arc::new(FakeSender::new());
-        let messenger = fake_telegram.clone().into();
         let config = Arc::new(Config {
             trufotbot_reminder_completion_delete_and_resend: true,
             trufotbot_show_dose_absolute_time: true,
             ..Config::load().unwrap()
         });
-        let app_state = AppState::new(db, messenger, config.clone()).await.unwrap();
+        let frontend_url = config.frontend_url.clone();
+        let (app_state, fake_telegram) = setup(db, config.clone()).await;
 
-        let taken_at = DateTime::parse_from_rfc3339("2025-01-02T00:00:00Z")
-            .unwrap()
-            .to_utc();
-        let reminded_at = DateTime::parse_from_rfc3339("2025-01-01T23:00:00Z")
-            .unwrap()
-            .to_utc();
+        let taken_at = dt("2025-01-02T00:00:00Z");
+        let reminded_at = dt("2025-01-01T23:00:00Z");
 
         // Send reminder at FAKE_TIME = 2025-01-02T00:00:00Z
         FAKE_TIME
@@ -436,7 +402,7 @@ mod tests {
                 send_reminder(
                     State(app_state.storage.clone()),
                     State(app_state.messenger.clone()),
-                    State(app_state.config.clone()),
+                    State(config.clone()),
                     Path((1, 1)),
                 )
                 .await
@@ -455,7 +421,7 @@ mod tests {
                     }),
                     State(app_state.storage.clone()),
                     State(app_state.messenger.clone()),
-                    State(app_state.config.clone()),
+                    State(config.clone()),
                     Json(dose::CreateDose {
                         quantity: 2.0,
                         taken_at,
@@ -472,26 +438,8 @@ mod tests {
             fake_telegram.messages.get_messages(-123).await.unwrap(),
             messages_from_slice(
                 &[(
-                    r"✅ Albert gave Alice Aspirin \(2\) now \(2025\-01\-02 \(Thu\) 00:00\)",
-                    &[
-                        (
-                            "Edit... ✏️",
-                            callbacks::Action::Link {
-                                url: url::Url::parse(
-                                    "http://0.0.0.0:8080/patients/1/medications/1/doses/1"
-                                )
-                                .unwrap()
-                            }
-                        ),
-                        (
-                            "Repeat 🔁",
-                            callbacks::Action::TakeNew {
-                                patient_id: 1,
-                                medication_id: 1,
-                                quantity: 2.0,
-                            },
-                        )
-                    ]
+                    &md("✅ Albert gave Alice Aspirin (2) now (2025-01-02 (Thu) 00:00)"),
+                    &dose_keyboard(1, 1, 1, 2.0, &frontend_url),
                 )],
                 2
             )
@@ -504,7 +452,7 @@ mod tests {
                     Path((1, 1, 1)),
                     State(app_state.messenger.clone()),
                     State(app_state.storage.clone()),
-                    State(app_state.config.clone()),
+                    State(config.clone()),
                     Json(dose::CreateDose {
                         quantity: 1.0,
                         taken_at,
@@ -522,26 +470,8 @@ mod tests {
             fake_telegram.messages.get_messages(-123).await.unwrap(),
             messages_from_slice(
                 &[(
-                    r"✏️ Bob gave Alice Aspirin \(1\) now \(2025\-01\-02 \(Thu\) 00:00\)",
-                    &[
-                        (
-                            "Edit... ✏️",
-                            callbacks::Action::Link {
-                                url: url::Url::parse(
-                                    "http://0.0.0.0:8080/patients/1/medications/1/doses/1"
-                                )
-                                .unwrap()
-                            }
-                        ),
-                        (
-                            "Repeat 🔁",
-                            callbacks::Action::TakeNew {
-                                patient_id: 1,
-                                medication_id: 1,
-                                quantity: 1.0,
-                            },
-                        )
-                    ]
+                    &md("✏️ Bob gave Alice Aspirin (1) now (2025-01-02 (Thu) 00:00)"),
+                    &dose_keyboard(1, 1, 1, 1.0, &frontend_url),
                 )],
                 2
             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,9 @@ mod storage;
 mod telegram_bot;
 mod time;
 
+#[cfg(test)]
+mod test_utils;
+
 #[derive(Parser)]
 #[command(version = env!("VERGEN_GIT_DESCRIBE"), about, long_about = None)]
 struct Args {

--- a/src/next_doses.rs
+++ b/src/next_doses.rs
@@ -69,6 +69,7 @@ mod tests {
             CreateDoseQueryParams, PatientCreateRequest, PatientMedicationCreateRequest,
         },
         app_state::Config,
+        test_utils::dt,
         time::FAKE_TIME,
     };
     use axum::{
@@ -141,9 +142,7 @@ mod tests {
                 State(Config::load().unwrap().into()),
                 Json(CreateDose {
                     quantity,
-                    taken_at: chrono::DateTime::parse_from_rfc3339(taken_at)
-                        .unwrap()
-                        .into(),
+                    taken_at: dt(taken_at),
                     noted_by_user: None,
                 }),
             )
@@ -159,9 +158,7 @@ mod tests {
             } else {
                 Some(quantity)
             },
-            time: chrono::DateTime::parse_from_rfc3339(taken_at)
-                .unwrap()
-                .into(),
+            time: dt(taken_at),
         }
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,78 @@
+#![cfg(test)]
+// Copyright (C) 2026 Ohad Lutzky <lutzky@gmail.com>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Shared test utilities: markdown escaping, timestamp parsing, URL builders,
+//! and keyboard factories.
+
+use chrono::{DateTime, Utc};
+use teloxide::utils::markdown;
+
+use crate::messenger::callbacks;
+
+/// Markdown-escape a string
+/// [`teloxide::utils::markdown::escape`].
+pub fn md(s: &str) -> String {
+    markdown::escape(s).to_string()
+}
+
+/// Parse an RFC 3339 timestamp into UTC
+pub fn dt(s: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(s).unwrap().to_utc()
+}
+
+/// Build a URL to a reminder (medication) page with message parameters.
+///
+/// We pass message_time as an i64 rather than a constructed time; this is to make it easier to
+/// validate the literal expectations in tests.
+pub fn reminder_url(
+    base: &url::Url,
+    patient_id: i64,
+    medication_id: i64,
+    message_id: i32,
+    message_time: i64,
+) -> url::Url {
+    let mut url = base.clone();
+    url.path_segments_mut()
+        .unwrap()
+        .push("patients")
+        .push(&patient_id.to_string())
+        .push("medications")
+        .push(&medication_id.to_string());
+    url.query_pairs_mut()
+        .append_pair("message_id", &message_id.to_string())
+        .append_pair("message_time", &message_time.to_string());
+    url
+}
+
+/// Build the recorded-dose keyboard ("Edit... ✏️" + "Repeat 🔁")
+pub fn dose_keyboard(
+    patient_id: i64,
+    medication_id: i64,
+    dose_id: i64,
+    quantity: f64,
+    base_url: &url::Url,
+) -> Vec<(&'static str, callbacks::Action)> {
+    let mut url = base_url.clone();
+    url.path_segments_mut()
+        .unwrap()
+        .push("patients")
+        .push(&patient_id.to_string())
+        .push("medications")
+        .push(&medication_id.to_string())
+        .push("doses")
+        .push(&dose_id.to_string());
+
+    vec![
+        ("Edit... ✏️", callbacks::Action::Link { url }),
+        (
+            "Repeat 🔁",
+            callbacks::Action::TakeNew {
+                patient_id,
+                medication_id,
+                quantity,
+            },
+        ),
+    ]
+}


### PR DESCRIPTION
Extract shared test infrastructure into a new src/test_utils.rs module (cfg(test)-gated):
  - md() — wraps markdown::escape for readable test strings, eliminating hard-to-read escaped raw strings and double-escaping
  - dt() — reduce repetition in DateTime parsing
  - dose_url() / reminder_url() — build URLs from config.frontend_url instead of hardcoded strings (less brittle)
  - dose_keyboard() — reduce repetition and deeply-nested structures scattered in test code

Refactor tests across reminders.rs and doses.rs:
  - Replace inline keyboards with dose_keyboard() (reminders.rs), replace local want_kbd_with_quantity (doses.rs)
  - Add config_with_absolute_time rstest fixture
  - Use setup() helper (FakeSender + AppState creation)
  - All test URLs built from config.frontend_url (dynamic, not hardcoded)
  - Apply dt() in next_doses.rs test helpers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test suite to use shared test utilities for improved consistency and maintainability.

* **Chores**
  * Consolidated test helper functions for timestamp parsing, markdown formatting, and keyboard action generation.

**Note:** These changes are internal improvements with no impact on user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lutzky/trufotbot/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->