### PR TITLE
fix: Fix dose-limits input corruption (#88) and improve save-button dirty tracking

### DIFF
--- a/frontend/e2e/medication-limits.spec.ts
+++ b/frontend/e2e/medication-limits.spec.ts
@@ -2,62 +2,299 @@
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
+
+const PATIENT_ID = 1
+const MEDICATION_ID = 1
+
+interface MockDosesBody {
+  patient_name: string
+  medication: { name: string; description: string; dose_limits: Array<{ hours: number; amount: number }> }
+  reminders: { cron_schedules: Array<string> }
+  doses: Array<unknown>
+  next_doses: Array<unknown>
+}
+
+function makeDosesResponse(doseLimits: Array<{ hours: number; amount: number }> = []): MockDosesBody {
+  return {
+    patient_name: 'Alice',
+    medication: { name: 'Aspirin', description: 'Pain reliever', dose_limits: doseLimits },
+    reminders: { cron_schedules: [] },
+    doses: [],
+    next_doses: [],
+  }
+}
+
+async function setupPage(page: Page, doseLimits: Array<{ hours: number; amount: number }> = []) {
+  const response = makeDosesResponse(doseLimits)
+  await page.route(`**/api/patients/${PATIENT_ID}/medications/${MEDICATION_ID}/doses`, async (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(response),
+    })
+  })
+}
+
+async function openEditForm(page: Page) {
+  await page.goto(`/patients/${PATIENT_ID}/medications/${MEDICATION_ID}`)
+  await page.waitForLoadState('domcontentloaded')
+  await page
+    .locator('details:has(summary:text("Edit medication"))')
+    .evaluate((el: HTMLDetailsElement) => (el.open = true))
+}
+
+function limitsInput(page: Page) {
+  return page.getByRole('textbox', { name: 'Limits' })
+}
+
+function saveButton(page: Page) {
+  return page.getByRole('button', { name: 'Save' })
+}
+
+async function setCursorPosition(input: ReturnType<typeof limitsInput>, pos: number) {
+  await input.evaluate((el: HTMLTextAreaElement, p: number) => {
+    el.setSelectionRange(p, p)
+  }, pos)
+}
 
 test.describe('Entering limits', () => {
   test('PatientMedicationDetailView - Entering limits, including the comma', async ({ page }) => {
-    const mockDosesResponse = {
-      patient_name: 'Alice',
-      medication: { name: 'Aspirin', description: 'Pain reliever', dose_limits: [] },
-      reminders: { cron_schedules: [] },
-      doses: [],
-      next_doses: [],
-    }
+    await setupPage(page)
+    await openEditForm(page)
 
-    await page.route('**/api/patients/1/medications/1/doses', async (route) => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(mockDosesResponse),
-      })
-    })
-
-    await test.step('Navigate to medication detail page', async () => {
-      await page.goto('/patients/1/medications/1')
-      await page.waitForLoadState('domcontentloaded')
-    })
-
-    await test.step('Open edit medication form', async () => {
-      await page
-        .locator('details:has(summary:text("Edit medication"))')
-        .evaluate((el: HTMLDetailsElement) => (el.open = true))
-    })
-
-    const limitsInput = page.getByRole('textbox', { name: 'Limits' })
+    const input = limitsInput(page)
 
     await test.step('Find limits input', async () => {
-      await expect(limitsInput).toBeVisible()
+      await expect(input).toBeVisible()
     })
 
     await test.step('Input limits "12:34,"', async () => {
-      await limitsInput.focus()
-      await limitsInput.clear()
-      await limitsInput.pressSequentially('12:34,', { delay: 10 })
+      await input.focus()
+      await input.clear()
+      await input.pressSequentially('12:34,', { delay: 10 })
     })
 
     await test.step('Should count as invalid, and have trailing comma', async () => {
-      await expect(limitsInput).toHaveValue('12:34,')
-      await expect(limitsInput).toHaveAttribute("aria-invalid", "true")
+      await expect(input).toHaveValue('12:34,')
+      await expect(input).toHaveAttribute('aria-invalid', 'true')
     })
 
     await test.step('Further input "56:7.8"', async () => {
-      await limitsInput.pressSequentially('56:7.', { delay: 10 })
-      await expect(limitsInput).toHaveValue('12:34,56:7.')
-      // Trailing period doesn't make it invalid, but also shouldn't disappear
-      await expect(limitsInput).toHaveAttribute("aria-invalid", "false")
-      await limitsInput.pressSequentially('8', { delay: 10 })
-      await expect(limitsInput).toHaveValue('12:34,56:7.8')
-      await expect(limitsInput).toHaveAttribute("aria-invalid", "false")
+      await input.pressSequentially('56:7.', { delay: 10 })
+      await expect(input).toHaveValue('12:34,56:7.')
+      await expect(input).toHaveAttribute('aria-invalid', 'false')
+      await input.pressSequentially('8', { delay: 10 })
+      await expect(input).toHaveValue('12:34,56:7.8')
+      await expect(input).toHaveAttribute('aria-invalid', 'false')
+    })
+  })
+})
+
+test.describe('Issue #88: Limits input bugs', () => {
+  // https://github.com/lutzky/trufotbot/issues/88
+  test.describe('Double period destruction', () => {
+    test('typing a period where one already exists does not erase text', async ({ page }) => {
+      await setupPage(page, [{ hours: 12, amount: 3.5 }])
+      await openEditForm(page)
+
+      const input = limitsInput(page)
+      await expect(input).toHaveValue('12:3.5')
+
+      await input.focus()
+      await setCursorPosition(input, 4) // between '3' and '.'
+      await input.pressSequentially('.', { delay: 10 })
+
+      await expect(input).toHaveValue('12:3..5')
+      await expect(input).toHaveAttribute('aria-invalid', 'true')
+    })
+  })
+
+  test.describe('Adding a period to non-last limit', () => {
+    test('typing a decimal point before a comma works', async ({ page }) => {
+      await setupPage(page)
+      await openEditForm(page)
+
+      const input = limitsInput(page)
+      await input.focus()
+      await input.fill('1:1,2:2')
+
+      await setCursorPosition(input, 3) // between '1' and ','
+      await input.pressSequentially('.5', { delay: 10 })
+
+      await expect(input).toHaveValue('1:1.5,2:2')
+      await expect(input).toHaveAttribute('aria-invalid', 'false')
+    })
+  })
+
+  test.describe('Leading period', () => {
+    test('typing "." after colon inserts period without rewriting to "0."', async ({ page }) => {
+      await setupPage(page)
+      await openEditForm(page)
+
+      const input = limitsInput(page)
+      await input.focus()
+      await input.fill('1:1')
+
+      await setCursorPosition(input, 2) // after ':'
+      await input.pressSequentially('.', { delay: 10 })
+
+      await expect(input).toHaveValue('1:.1')
+      await expect(input).toHaveAttribute('aria-invalid', 'false')
+    })
+  })
+
+  test.describe('Save button dirty tracking', () => {
+    test('save button toggles correctly and sends correct body', async ({ page }) => {
+      await setupPage(page)
+      await openEditForm(page)
+
+      const input = limitsInput(page)
+      const btn = saveButton(page)
+
+      let savedBody: unknown = null
+      let putCount = 0
+      await page.route(`**/api/patients/${PATIENT_ID}/medications/${MEDICATION_ID}`, async (route) => {
+        if (route.request().method() === 'PUT') {
+          savedBody = route.request().postDataJSON()
+          putCount += 1
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({}),
+          })
+        }
+        return route.fulfill({ status: 404 })
+      })
+
+      await test.step('Initially disabled (no changes)', async () => {
+        await expect(btn).toBeDisabled()
+      })
+
+      await test.step('Enabled after typing valid limits', async () => {
+        await input.focus()
+        await input.fill('12:3.5')
+        await expect(btn).toBeEnabled()
+      })
+
+      await test.step('Disabled after clicking save, body matches input', async () => {
+        await btn.click()
+        await expect(btn).toBeDisabled()
+        expect(putCount).toBe(1)
+        expect(savedBody).toEqual({
+          medication: { name: 'Aspirin', description: 'Pain reliever', dose_limits: [{ hours: 12, amount: 3.5 }] },
+          reminders: { cron_schedules: [] },
+        })
+      })
+    })
+
+    test('save button disabled when limits become invalid, re-enabled when fixed', async ({ page }) => {
+      await setupPage(page)
+      await openEditForm(page)
+
+      const input = limitsInput(page)
+      const btn = saveButton(page)
+
+      await test.step('Type valid "12:34" → enabled', async () => {
+        await input.focus()
+        await input.pressSequentially('12:34', { delay: 10 })
+        await expect(btn).toBeEnabled()
+      })
+
+      await test.step('Type trailing comma "12:34," → disabled', async () => {
+        await input.pressSequentially(',', { delay: 10 })
+        await expect(btn).toBeDisabled()
+      })
+
+      await test.step('Backspace to "12:34" → enabled again', async () => {
+        await page.keyboard.press('Backspace')
+        await expect(btn).toBeEnabled()
+      })
+    })
+  })
+
+  test.describe('Save leading period without blur', () => {
+    test('edit "1:1" → "1:.1" saves amount 0.1 not 1', async ({ page }) => {
+      await setupPage(page, [{ hours: 1, amount: 1 }])
+      await openEditForm(page)
+
+      const nameInput = page.getByPlaceholder('Medication name')
+      const limits = limitsInput(page)
+      const btn = saveButton(page)
+
+      const savedBodies: Array<unknown> = []
+      let putCount = 0
+      await page.route(`**/api/patients/${PATIENT_ID}/medications/${MEDICATION_ID}`, async (route) => {
+        if (route.request().method() === 'PUT') {
+          putCount += 1
+          savedBodies.push(route.request().postDataJSON())
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({}),
+          })
+        }
+        return route.fulfill({ status: 404 })
+      })
+
+      await test.step('Initially shows "1:1"', async () => {
+        await expect(limits).toHaveValue('1:1')
+      })
+
+      await test.step('Dirty form with a name change, then save sends amount 1', async () => {
+        await nameInput.focus()
+        await nameInput.press('End')
+        await nameInput.pressSequentially('!', { delay: 10 })
+        await btn.click()
+        expect(putCount).toBe(1)
+        expect(savedBodies[0]).toEqual({
+          medication: { name: 'Aspirin!', description: 'Pain reliever', dose_limits: [{ hours: 1, amount: 1 }] },
+          reminders: { cron_schedules: [] },
+        })
+        // Wait for saveMedication's finally block to update
+        // originalMedicationJson before we modify the model, otherwise
+        // the finally block captures the new state and isDirty stays false.
+        await expect(btn).not.toHaveAttribute('aria-busy', 'true')
+      })
+
+      await test.step('Type "." after colon → shows "1:.1" (not "1:0.1")', async () => {
+        await limits.focus()
+        await setCursorPosition(limits, 2)
+        await limits.pressSequentially('.', { delay: 10 })
+        await expect(limits).toHaveValue('1:.1')
+      })
+
+      await test.step('Save again sends amount 0.1', async () => {
+        await expect(btn).toBeEnabled()
+        await btn.click()
+        expect(putCount).toBe(2)
+        expect(savedBodies[1]).toEqual({
+          medication: { name: 'Aspirin!', description: 'Pain reliever', dose_limits: [{ hours: 1, amount: 0.1 }] },
+          reminders: { cron_schedules: [] },
+        })
+      })
+    })
+  })
+
+  test.describe('Blur normalization', () => {
+    test('typing "1:.1,2:2." then tabbing away normalizes to "1:0.1,2:2"', async ({ page }) => {
+      await setupPage(page)
+      await openEditForm(page)
+
+      const input = limitsInput(page)
+
+      await test.step('Type "1:.1,2:2." → shown as typed', async () => {
+        await input.focus()
+        await input.pressSequentially('1:.1,2:2.', { delay: 10 })
+        await expect(input).toHaveValue('1:.1,2:2.')
+        await expect(input).toHaveAttribute('aria-invalid', 'false')
+      })
+
+      await test.step('Tab away → normalizes to "1:0.1,2:2"', async () => {
+        await page.keyboard.press('Tab')
+        await expect(input).toHaveValue('1:0.1,2:2')
+        await expect(input).toHaveAttribute('aria-invalid', 'false')
+      })
     })
   })
 })

--- a/frontend/src/components/DoseLimitsEditor.vue
+++ b/frontend/src/components/DoseLimitsEditor.vue
@@ -1,0 +1,111 @@
+<!--
+Copyright (C) 2026 Ohad Lutzky <lutzky@gmail.com>
+
+SPDX-License-Identifier: GPL-3.0-only
+-->
+
+<script setup lang="ts">
+import type { DoseLimit } from '@/openapi'
+import { ref, watch } from 'vue'
+
+const doseLimits = defineModel<Array<DoseLimit>>('doseLimits', { required: true })
+
+const emit = defineEmits<{
+  (e: 'validity-change', isValid: boolean): void
+}>()
+
+const rawInput = ref<string>('')
+const isFocused = ref<boolean>(false)
+const isValid = ref<boolean>(true)
+
+function splitOnce(s: string, d: string): [string, string | undefined] {
+  const idx = s.indexOf(d)
+  return idx === -1 ? [s, undefined] : [s.substring(0, idx), s.substring(idx + 1)]
+}
+
+function canonicalizeInput(limits: Array<DoseLimit>) {
+  rawInput.value = limits.map((l) => `${l.hours}:${l.amount}`).join(',')
+}
+
+function parseLimits(input: string): Array<DoseLimit> | null {
+  if (input === '') return []
+
+  const parts = input.split(',')
+  const result: Array<DoseLimit> = []
+
+  for (const part of parts) {
+    let [hoursStr, amountStr] = splitOnce(part, ':')
+    if (amountStr === undefined) return null
+    hoursStr = hoursStr.trim()
+    amountStr = amountStr.trim()
+    if (hoursStr === '' || amountStr === '') return null
+    const hours = Number(hoursStr)
+    const amount = Number(amountStr)
+    if (!Number.isFinite(hours) || !Number.isFinite(amount)) return null
+    if (!Number.isInteger(hours)) return null
+    result.push({ hours, amount })
+  }
+  return result
+}
+
+function processInput(text: string) {
+  const trimmed = text.trim()
+  if (trimmed === '') {
+    isValid.value = true
+    doseLimits.value = []
+    emit('validity-change', true)
+    return
+  }
+  const parsed = parseLimits(trimmed)
+  if (parsed !== null) {
+    isValid.value = true
+    doseLimits.value = parsed
+  } else {
+    isValid.value = false
+  }
+  emit('validity-change', isValid.value)
+}
+
+watch(rawInput, (val) => processInput(val))
+
+watch(
+  doseLimits,
+  (limits) => {
+    if (!isFocused.value) {
+      canonicalizeInput(limits)
+    }
+  },
+  { immediate: true, deep: true },
+)
+
+function onInput(e: Event) {
+  rawInput.value = (e.target as HTMLTextAreaElement).value
+}
+
+function onBlur() {
+  isFocused.value = false
+  const trimmed = rawInput.value.trim()
+  const parsed = parseLimits(trimmed)
+  if (parsed !== null) {
+    canonicalizeInput(parsed)
+  }
+}
+
+function onFocus() {
+  isFocused.value = true
+}
+</script>
+
+<template>
+  <label>
+    Limits
+    <textarea
+      :aria-invalid="!isValid"
+      placeholder="hours:amount,hours:amount,..."
+      :value="rawInput"
+      @input="onInput"
+      @blur="onBlur"
+      @focus="onFocus"
+    />
+  </label>
+</template>

--- a/frontend/src/components/MedicationDetails.vue
+++ b/frontend/src/components/MedicationDetails.vue
@@ -7,7 +7,8 @@ SPDX-License-Identifier: GPL-3.0-only
 <script setup lang="ts">
 import cronstrue from 'cronstrue'
 import type { DoseLimit } from '@/openapi'
-import { computed, ref, watch, watchEffect } from 'vue'
+import { computed, ref, watch } from 'vue'
+import DoseLimitsEditor from './DoseLimitsEditor.vue'
 
 defineProps<{ creating?: boolean }>()
 
@@ -52,50 +53,15 @@ const scheduleExplanations = computed<{ isValid: boolean; explanation: string }>
   }
 })
 
-const rawLimitsInput = ref<string>('')
-const invalidLimits = ref<boolean>(false)
+const limitsAreValid = ref<boolean>(true)
 
-watch([scheduleExplanations, invalidLimits], () => {
-  emit('update:isValid', !invalidLimits.value && scheduleExplanations.value.isValid)
-})
-
-watchEffect(() => {
-  rawLimitsInput.value = doseLimits.value.map((lim) => `${lim.hours}:${lim.amount}`).join(',')
-})
-
-function parseLimitsInput() {
-  const input = rawLimitsInput.value
-
-  if (input == '') {
-    invalidLimits.value = false
-    doseLimits.value = []
-    return
-  }
-
-  const parsed = []
-  const parts = input.split(',')
-
-  for (const part of parts) {
-    const [hoursStr, amountStr] = part.split(':')
-    const hours = parseInt(hoursStr)
-    const amount = parseFloat(amountStr)
-
-    if (!isNaN(hours) && !isNaN(amount)) {
-      parsed.push({ hours, amount })
-    } else {
-      invalidLimits.value = true
-      return
-    }
-  }
-
-  invalidLimits.value = false
-
-  if (input.endsWith('.') || input.endsWith(':') || input.endsWith(',')) {
-    // User is currently typing; do not update model, as that will remove the last character
-  } else {
-    doseLimits.value = parsed
-  }
-}
+watch(
+  [scheduleExplanations, limitsAreValid],
+  () => {
+    emit('update:isValid', limitsAreValid.value && scheduleExplanations.value.isValid)
+  },
+  { immediate: true },
+)
 </script>
 
 <template>
@@ -179,13 +145,6 @@ function parseLimitsInput() {
       v-model="cronScheduleAsString"
     ></textarea>
     <small>{{ scheduleExplanations.explanation }}</small>
-    <label for="limits">Limits</label>
-    <textarea
-      id="limits"
-      :aria-invalid="invalidLimits"
-      placeholder="Limits (hours:amount,hours:amount,...)"
-      v-model="rawLimitsInput"
-      @input="parseLimitsInput"
-    ></textarea>
+    <DoseLimitsEditor v-model:doseLimits="doseLimits" @validity-change="limitsAreValid = $event" />
   </template>
 </template>

--- a/frontend/src/views/PatientMedicationDetailView.vue
+++ b/frontend/src/views/PatientMedicationDetailView.vue
@@ -27,7 +27,6 @@ const isLoading = ref(true)
 const loadError = ref<string | null>(null)
 
 const isMedicationSaving = ref(false)
-const isMedicationSaved = ref(false)
 const medicationSaveError = ref<string | null>(null)
 
 const isMedicationDeleting = ref(false)
@@ -102,6 +101,7 @@ async function loadData() {
     doseToCreate.value.quantity = latestQuantity(data)
     medication.value.medication = data?.medication
     medication.value.reminders = data?.reminders
+    originalMedicationJson.value = JSON.stringify(medication.value)
   } catch (err) {
     loadError.value = getErrorMessage(err)
   } finally {
@@ -116,6 +116,13 @@ const medicationFormValid = ref(true)
 function handleMedicationFormValidity(isValid: boolean) {
   medicationFormValid.value = isValid
 }
+
+const originalMedicationJson = ref<string | null>(null)
+
+const isDirty = computed(() => {
+  if (originalMedicationJson.value === null) return false
+  return JSON.stringify(medication.value) !== originalMedicationJson.value
+})
 
 async function logDose() {
   const params: Parameters<typeof dosesRecord>[0] = {
@@ -145,7 +152,7 @@ async function saveMedication() {
       path: { patient_id: props.patientId, medication_id: props.medicationId },
       body: medication.value,
     })
-    isMedicationSaved.value = true
+    originalMedicationJson.value = JSON.stringify(medication.value)
   } catch (error) {
     medicationSaveError.value = getErrorMessage(error)
   } finally {
@@ -285,11 +292,6 @@ async function deleteMedication() {
           v-model:doseLimits="medication.medication.dose_limits"
           v-model:reminders="medication.reminders.cron_schedules"
           @update:isValid="handleMedicationFormValidity"
-          @update:name="isMedicationSaved = false"
-          @update:description="isMedicationSaved = false"
-          @update:inventory="isMedicationSaved = false"
-          @update:doseLimits="isMedicationSaved = false"
-          @update:reminders="isMedicationSaved = false"
         />
         <article v-if="medicationSaveError" class="pico-background-red">
           {{ medicationSaveError }}
@@ -302,7 +304,7 @@ async function deleteMedication() {
               !medicationFormValid ||
               isMedicationSaving ||
               isMedicationDeleting ||
-              isMedicationSaved
+              !isDirty
             "
             :aria-busy="isMedicationSaving"
           >


### PR DESCRIPTION
The dose-limits textarea in MedicationDetails used v-model + manual parse on @input, which corrupted the display when typing leading periods or extra periods (issue #88).  Extract a self-contained DoseLimitsEditor component with a decoupled rawInput/model pattern:

- `processInput` parses rawInput on every keystroke and updates the model only when valid, never overwriting the textarea.
- `canonicalizeInput` normalizes the display text on blur (e.g. `1:.1` → `1:0.1`) and when loading data, without interfering during typing (guarded by `isFocused`).
- `splitOnce` + `Number()` replace fragile `String.split(':')` + `parseInt`/`parseFloat` — catches extra colons and non-finite values.

Replace `isMedicationSaved` (five fragile `@update:*` handlers) with `isDirty` computed that compares the current `medication` ref against a stringified JSON snapshot taken at load and after each save.

E2E tests cover double periods, periods before commas, leading periods, save-button dirty tracking, invalidity disabling, blur normalization, and a race-condition fix where `saveMedication`'s finally block would overwrite `originalMedicationJson` after the model had already changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated dose limits editor for medication details with smarter input parsing and automatic normalization when appropriate.

* **Bug Fixes**
  * Improved validation for common entry edge cases (e.g., trailing commas, decimal formatting, leading decimals) and ensured correct payload formatting when saving.
  * Updated form state so the Save button enables only when the medication details have real unsaved changes.

* **Tests**
  * Expanded end-to-end coverage for dose limits validation, normalization behavior, and save request contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->