### PR TITLE
Improve dose notification emojis

### DIFF
--- a/src/app_state/mod.rs
+++ b/src/app_state/mod.rs
@@ -72,9 +72,15 @@ impl Config {
 
         let raw_url = self.frontend_url.as_str();
         log::warn!(
-            "FRONTEND_URL {raw_url:?} has a host with no dots ({host:?}), links might fail to render. See e.g. https://github.com/telegramdesktop/tdesktop/issues/7827
-
-Hint: Try localhost.localdomain, 127.0.0.1, 0.0.0.0, the target's IP address");
+            concat!(
+                "FRONTEND_URL {raw_url:?} has a host with no dots ({host:?}), ",
+                "links might fail to render. See e.g. ",
+                "https://github.com/telegramdesktop/tdesktop/issues/7827\n\n",
+                "Hint: Try localhost.localdomain, 127.0.0.1, 0.0.0.0, the target's IP address",
+            ),
+            raw_url = raw_url,
+            host = host,
+        );
     }
 
     pub fn check_user(&self, user_id: Option<&str>) -> eyre::Result<()> {

--- a/src/handlers/doses.rs
+++ b/src/handlers/doses.rs
@@ -172,12 +172,16 @@ enum NotificationType {
     Edited(ChatId, MessageId, DateTime<Utc>),
 }
 
-impl core::fmt::Display for NotificationType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl NotificationType {
+    fn prefix(&self, dose: &Dose) -> &'static str {
+        let skipped = dose.data.quantity == 0.0;
         match self {
-            NotificationType::Normal => write!(f, ""),
-            NotificationType::ReminderDone(_, _) => write!(f, "✅ "),
-            NotificationType::Edited(_, _, _) => write!(f, "✏️ "),
+            NotificationType::Normal if skipped => "⏭️ ",
+            NotificationType::Normal => "💊 ",
+            NotificationType::ReminderDone(_, _) if skipped => "⏭️ ",
+            NotificationType::ReminderDone(_, _) => "✅ ",
+            NotificationType::Edited(_, _, _) if skipped => "✏️⏭️ ",
+            NotificationType::Edited(_, _, _) => "✏️✅ ",
         }
     }
 }
@@ -214,7 +218,7 @@ async fn notify(
 
     let edit_url = edit_dose_url(patient, medication, dose.id, config);
 
-    let message = format!("{notification_type}{base_msg}");
+    let message = format!("{}{base_msg}", notification_type.prefix(dose));
 
     let keyboard = [
         match edit_url {
@@ -1055,10 +1059,10 @@ mod tests {
         );
 
         let initial_message =
-            &md("Alice took Aspirin (2) an hour earlier (2025-01-01 (Wed) 23:00)");
+            &md("💊 Alice took Aspirin (2) an hour earlier (2025-01-01 (Wed) 23:00)");
         let initial_keyboard = dose_keyboard(1, 1, 1, 2.0, &frontend_url);
         let edited_message =
-            &md("✏️ Bob gave Alice Aspirin (1) an hour earlier (2025-01-01 (Wed) 23:00)");
+            &md("✏️✅ Bob gave Alice Aspirin (1) an hour earlier (2025-01-01 (Wed) 23:00)");
         let edited_keyboard = dose_keyboard(1, 1, 1, 1.0, &frontend_url);
 
         if !fake_telegram_starts_broken {

--- a/src/handlers/reminders.rs
+++ b/src/handlers/reminders.rs
@@ -168,7 +168,7 @@ pub async fn send_reminder(
     let default_dosage = latest_dosage.unwrap_or(1.0);
 
     let base_message = markdown::escape(&format!(
-        "Time for {} to take {}.",
+        "🔔 Time for {} to take {}.",
         patient.name, medication.name
     ));
 
@@ -279,7 +279,7 @@ mod tests {
         (app_state, fake_telegram)
     }
 
-    async fn test_remind_dose(db: SqlitePool, delete_and_resend: bool) {
+    async fn test_remind_dose(db: SqlitePool, delete_and_resend: bool, quantity: f64) {
         let config = Arc::new(Config {
             trufotbot_reminder_completion_delete_and_resend: delete_and_resend,
             trufotbot_show_dose_absolute_time: true,
@@ -324,7 +324,7 @@ mod tests {
 
         assert_eq!(
             fake_telegram.messages.get_messages(-123).await.unwrap(),
-            messages_from_slice(&[(&md("Time for Alice to take Aspirin."), &keyboard)], 1)
+            messages_from_slice(&[(&md("🔔 Time for Alice to take Aspirin."), &keyboard)], 1)
         );
 
         let taken_at = dt("2025-01-01T23:00:00Z");
@@ -342,7 +342,7 @@ mod tests {
                     State(app_state.messenger.clone()),
                     State(app_state.config.clone()),
                     Json(dose::CreateDose {
-                        quantity: 2.0,
+                        quantity,
                         taken_at,
                         noted_by_user: Some("Albert".to_string()),
                     }),
@@ -354,12 +354,40 @@ mod tests {
 
         let (expected_text, expected_id) = if delete_and_resend {
             (
-                md("✅ Albert gave Alice Aspirin (2) an hour earlier (2025-01-01 (Wed) 23:00)"),
+                md(&if quantity == 0.0 {
+                    concat!(
+                        "⏭️ Albert decided to skip giving Alice Aspirin (0) an hour earlier ",
+                        "(2025-01-01 (Wed) 23:00)"
+                    )
+                    .to_string()
+                } else {
+                    format!(
+                        concat!(
+                            "✅ Albert gave Alice Aspirin ({quantity})",
+                            " an hour earlier (2025-01-01 (Wed) 23:00)",
+                        ),
+                        quantity = quantity,
+                    )
+                }),
                 2,
             )
         } else {
             (
-                md("✅ Albert gave Alice Aspirin (2) an hour later (2025-01-01 (Wed) 23:00)"),
+                md(&if quantity == 0.0 {
+                    concat!(
+                        "⏭️ Albert decided to skip giving Alice Aspirin (0) an hour later ",
+                        "(2025-01-01 (Wed) 23:00)"
+                    )
+                    .to_string()
+                } else {
+                    format!(
+                        concat!(
+                            "✅ Albert gave Alice Aspirin ({quantity})",
+                            " an hour later (2025-01-01 (Wed) 23:00)",
+                        ),
+                        quantity = quantity,
+                    )
+                }),
                 1,
             )
         };
@@ -367,7 +395,10 @@ mod tests {
         assert_eq!(
             fake_telegram.messages.get_messages(-123).await.unwrap(),
             messages_from_slice(
-                &[(&expected_text, &dose_keyboard(1, 1, 1, 2.0, &frontend_url),)],
+                &[(
+                    &expected_text,
+                    &dose_keyboard(1, 1, 1, quantity, &frontend_url),
+                )],
                 expected_id
             )
         );
@@ -375,12 +406,22 @@ mod tests {
 
     #[sqlx::test(fixtures("../fixtures/patients.sql", "../fixtures/medications.sql"))]
     async fn remind_dose_succeeds_with_edit(db: SqlitePool) {
-        test_remind_dose(db, false).await;
+        test_remind_dose(db, false, 2.0).await;
     }
 
     #[sqlx::test(fixtures("../fixtures/patients.sql", "../fixtures/medications.sql"))]
     async fn remind_dose_succeeds_with_delete_and_resend(db: SqlitePool) {
-        test_remind_dose(db, true).await;
+        test_remind_dose(db, true, 2.0).await;
+    }
+
+    #[sqlx::test(fixtures("../fixtures/patients.sql", "../fixtures/medications.sql"))]
+    async fn remind_dose_skip_succeeds_with_edit(db: SqlitePool) {
+        test_remind_dose(db, false, 0.0).await;
+    }
+
+    #[sqlx::test(fixtures("../fixtures/patients.sql", "../fixtures/medications.sql"))]
+    async fn remind_dose_skip_succeeds_with_delete_and_resend(db: SqlitePool) {
+        test_remind_dose(db, true, 0.0).await;
     }
 
     #[sqlx::test(fixtures("../fixtures/patients.sql", "../fixtures/medications.sql"))]
@@ -470,8 +511,106 @@ mod tests {
             fake_telegram.messages.get_messages(-123).await.unwrap(),
             messages_from_slice(
                 &[(
-                    &md("✏️ Bob gave Alice Aspirin (1) now (2025-01-02 (Thu) 00:00)"),
+                    &md("✏️✅ Bob gave Alice Aspirin (1) now (2025-01-02 (Thu) 00:00)"),
                     &dose_keyboard(1, 1, 1, 1.0, &frontend_url),
+                )],
+                2
+            )
+        );
+    }
+
+    #[sqlx::test(fixtures("../fixtures/patients.sql", "../fixtures/medications.sql"))]
+    async fn remind_dose_then_edit_to_skip_succeeds_with_delete_and_resend(db: SqlitePool) {
+        let config = Arc::new(Config {
+            trufotbot_reminder_completion_delete_and_resend: true,
+            trufotbot_show_dose_absolute_time: true,
+            ..Config::load().unwrap()
+        });
+        let frontend_url = config.frontend_url.clone();
+        let (app_state, fake_telegram) = setup(db, config.clone()).await;
+
+        let taken_at = dt("2025-01-02T00:00:00Z");
+        let reminded_at = dt("2025-01-01T23:00:00Z");
+
+        // Send reminder at FAKE_TIME = 2025-01-02T00:00:00Z
+        FAKE_TIME
+            .scope("2025-01-02T00:00:00Z", async {
+                send_reminder(
+                    State(app_state.storage.clone()),
+                    State(app_state.messenger.clone()),
+                    State(config.clone()),
+                    Path((1, 1)),
+                )
+                .await
+                .unwrap();
+            })
+            .await;
+
+        // Record dose from reminder (with reminded_at = 1 hour before now, taken_at = now)
+        FAKE_TIME
+            .scope("2025-01-02T00:00:00Z", async {
+                crate::handlers::doses::record(
+                    Path((1, 1)),
+                    Query(CreateDoseQueryParams {
+                        reminder_message_id: Some(1),
+                        reminder_sent_time: Some(reminded_at),
+                    }),
+                    State(app_state.storage.clone()),
+                    State(app_state.messenger.clone()),
+                    State(config.clone()),
+                    Json(dose::CreateDose {
+                        quantity: 2.0,
+                        taken_at,
+                        noted_by_user: Some("Albert".to_string()),
+                    }),
+                )
+                .await
+                .unwrap();
+            })
+            .await;
+
+        // Verify initial message says "now" (message_time = taken_at = now())
+        assert_eq!(
+            fake_telegram.messages.get_messages(-123).await.unwrap(),
+            messages_from_slice(
+                &[(
+                    &md("✅ Albert gave Alice Aspirin (2) now (2025-01-02 (Thu) 00:00)"),
+                    &dose_keyboard(1, 1, 1, 2.0, &frontend_url),
+                )],
+                2
+            )
+        );
+
+        // Update the dose (edit) at FAKE_TIME = 2025-01-02T00:05:00Z, skipping it
+        FAKE_TIME
+            .scope("2025-01-02T00:05:00Z", async {
+                crate::handlers::doses::update(
+                    Path((1, 1, 1)),
+                    State(app_state.messenger.clone()),
+                    State(app_state.storage.clone()),
+                    State(config.clone()),
+                    Json(dose::CreateDose {
+                        quantity: 0.0,
+                        taken_at,
+                        noted_by_user: Some("Bob".to_string()),
+                    }),
+                )
+                .await
+                .unwrap();
+            })
+            .await;
+
+        // Verify edited message still says "now" (DB-stored telegram_message_time = now(), not
+        // reminded_at).
+        assert_eq!(
+            fake_telegram.messages.get_messages(-123).await.unwrap(),
+            messages_from_slice(
+                &[(
+                    &md(concat!(
+                        "✏️⏭️ Bob decided to skip giving Alice Aspirin (0) now ",
+                        "(2025-01-02 (Thu) 00:00)"
+                    )),
+                    &dose_keyboard(1, 1, 1, 0.0, &frontend_url),
                 )],
                 2
             )

--- a/src/messenger/telegram_sender.rs
+++ b/src/messenger/telegram_sender.rs
@@ -19,8 +19,12 @@ fn maybe_warn_about_long_callback(json_data: &str) {
     );
     if json_data.len() > 64 {
         log::error!(
-            "Generating callback data from this JSON with length {} > 64, which will fail: {json_data}",
-            json_data.len()
+            concat!(
+                "Generating callback data from this JSON with length {} > 64, ",
+                "which will fail: {json_data}",
+            ),
+            json_data.len(),
+            json_data = json_data,
         );
     }
 }

--- a/src/reminder_scheduler.rs
+++ b/src/reminder_scheduler.rs
@@ -203,7 +203,13 @@ impl ReminderScheduler {
                 let callback = self.callback.clone();
                 tokio_cron_scheduler::Job::new_tz(schedule.clone(), chrono::Local, move |_, _| {
                     log::debug!(
-                        "Calling reminder callback for {patient_id:?}, {medication_id:?} on schedule {schedule:?}",
+                        concat!(
+                            "Calling reminder callback for {patient_id:?}, {medication_id:?} ",
+                            "on schedule {schedule:?}",
+                        ),
+                        patient_id = patient_id,
+                        medication_id = medication_id,
+                        schedule = schedule,
                     );
                     callback(patient_id, medication_id);
                 })

--- a/src/telegram_bot.rs
+++ b/src/telegram_bot.rs
@@ -347,7 +347,12 @@ async fn callback_handler(
 
     if reminder_sent_time.is_none() || message_id.is_none() {
         log::warn!(
-            "Received callback with message_id {message_id:?} and date {reminder_sent_time:?}; neither should be None"
+            concat!(
+                "Received callback with message_id {message_id:?} and date ",
+                "{reminder_sent_time:?}; neither should be None",
+            ),
+            message_id = message_id,
+            reminder_sent_time = reminder_sent_time,
         );
     }
 


### PR DESCRIPTION
- Skipped doses show ⏭️ (also when skipped manually).
- Edited doses show ✏️⏭️/✏️✅.
- Normal taken doses show 💊.
- Reminder prompts show 🔔.

Fixes https://github.com/lutzky/trufotbot/issues/71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Medication and reminder messages now include clearer icons for completed, skipped, edited, and pending doses.
  * Reminder notifications include a bell icon.
  * Editing a dose to zero now displays it as skipped while preserving the original reminder time.
  * Dose actions continue to support taking, skipping, editing, and deleting reminders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->